### PR TITLE
Fix template children being ignored

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MIX_ENV: prod
       ELIXIR_VERSION: "1.15.3"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - "v*.*"
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -154,6 +154,14 @@ defmodule LazyHTMLTest do
       assert LazyHTML.to_html(lazy_html, skip_whitespace_nodes: true) ==
                "<p><span> Hello </span><span> world </span></p>"
     end
+
+    test "includes template children" do
+      lazy_html =
+        LazyHTML.from_fragment("<template><div>First</div><div>Second</div></template>")
+
+      assert LazyHTML.to_html(lazy_html) ==
+               "<template><div>First</div><div>Second</div></template>"
+    end
   end
 
   describe "to_tree/2" do
@@ -173,6 +181,32 @@ defmodule LazyHTMLTest do
       assert LazyHTML.to_tree(lazy_html, sort_attributes: true) == [
                {"div", [{"data-a", "a"}, {"data-b", "b"}, {"id", "root"}], ["Hello world"]}
              ]
+    end
+
+    test "includes template children" do
+      lazy_html =
+        LazyHTML.from_fragment("<template><div>First</div><div>Second</div></template>")
+
+      assert LazyHTML.to_tree(lazy_html) == [
+               {"template", [], [{"div", [], ["First"]}, {"div", [], ["Second"]}]}
+             ]
+    end
+  end
+
+  describe "from_tree/2" do
+    test "includes template children" do
+      lazy_html =
+        LazyHTML.from_tree([
+          {"template", [], [{"div", [], ["First"]}, {"div", [], ["Second"]}]}
+        ])
+
+      assert inspect(lazy_html) == """
+             #LazyHTML<
+               1 node
+               #1
+               <template><div>First</div><div>Second</div></template>
+             >\
+             """
     end
   end
 


### PR DESCRIPTION
In the DOM API `<template>` elements don't have direct children, instead they have a `content` property, which returns a `#document-fragment` node, and this node has the actual children.

The Lexbor C API mirrors that exactly, so we need to account for it when working with the whole document (`to_tree`, `to_html`, `from_tree`).

On a sidenote, `LazyHTML.query` ignores elements within `<template>`s, but that matches the browser behaviour, so I think we are good.

The only function I am not sure about is `child_nodes`. In the browser `template.firstChild` is `null` and `template.childElementCount` is `0`. Thoughts?