### PR TITLE
config: don't set config at all outside test env.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,5 @@
 import Config
 
 # We disable the extra newline in test env, because it breaks doctests.
-config :lazy_html, :inspect_extra_newline, config_env() != :test
+if config_env() == :test,
+  do: config(:lazy_html, :inspect_extra_newline, false)


### PR DESCRIPTION
This is to avoid downstream users encountering the following in production builds (without further configuration):

```
ERROR! the application :lazy_html has a different value set for key :inspect_extra_newline during
runtime compared to compile time. Since this application environment entry was marked as compile
time, this difference can lead to different behavior than expected:

  * Compile time value was set to: true
  * Runtime value was not set
```