### PR TITLE
Add LazyHTML.html_escape/1

### DIFF
--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -481,6 +481,26 @@ defmodule LazyHTML do
     LazyHTML.NIF.tag(lazy_html)
   end
 
+  @doc ~S"""
+  Escapes the given string to make a valid HTML text.
+
+  ## Examples
+
+      iex> LazyHTML.html_escape("foo")
+      "foo"
+
+      iex> LazyHTML.html_escape("<foo>")
+      "&lt;foo&gt;"
+
+      iex> LazyHTML.html_escape("quotes: \" & \'")
+      "quotes: &quot; &amp; &#39;"
+
+  """
+  @spec html_escape(String.t()) :: String.t()
+  def html_escape(string) when is_binary(string) do
+    LazyHTML.Tree.append_escaped(string, "")
+  end
+
   # Access
 
   @impl true

--- a/lib/lazy_html/tree.ex
+++ b/lib/lazy_html/tree.ex
@@ -133,7 +133,8 @@ defmodule LazyHTML.Tree do
   #
   # [1]: https://github.com/phoenixframework/phoenix_html/blob/v4.2.1/lib/phoenix_html/engine.ex#L29-L35
 
-  defp append_escaped(text, html) do
+  @doc false
+  def append_escaped(text, html) do
     append_escaped(text, text, 0, 0, html)
   end
 


### PR DESCRIPTION
Escaping can be useful when matching against HTML strings (for example, in tests). Technically the behaviour is the same as `Plug.HTML.html_escape/1`, but it's good to have it in `LazyHTML` for discoverability.