### PR TITLE
Add LazyHTML.Tree.traverse/3

### DIFF
--- a/lib/lazy_html/tree.ex
+++ b/lib/lazy_html/tree.ex
@@ -172,6 +172,36 @@ defmodule LazyHTML.Tree do
   @doc """
   Performs a depth-first, post-order traversal of the given tree.
 
+  This function traverses the tree without modifying it, check `postwalk/2` and
+  `postwalk/3` if you need to modify the tree.
+  """
+  @spec traverse(
+          t(),
+          acc,
+          (html_node(), acc -> acc)
+        ) :: acc
+        when acc: term()
+  def traverse(tree, acc, fun), do: do_traverse(tree, acc, fun)
+
+  defp do_traverse([], acc, _fun), do: acc
+
+  defp do_traverse([node | rest], acc, fun) do
+    acc = do_traverse(node, acc, fun)
+    do_traverse(rest, acc, fun)
+  end
+
+  defp do_traverse({tag, attrs, children}, acc, fun) do
+    acc = do_traverse(children, acc, fun)
+    fun.({tag, attrs, children}, acc)
+  end
+
+  defp do_traverse(node, acc, fun) do
+    fun.(node, acc)
+  end
+
+  @doc """
+  Performs a depth-first, post-order traversal of the given tree.
+
   The mapper `fun` can return a list of nodes to replace the given
   node. In order to remove a node, return an empty list.
   """

--- a/test/lazy_html/tree_test.exs
+++ b/test/lazy_html/tree_test.exs
@@ -60,6 +60,33 @@ defmodule LazyHTML.TreeTest do
     end
   end
 
+  describe "traverse/3" do
+    test "does post-order traversal of the nodes and accumulates results" do
+      tree = [
+        {:comment, "Hello world"},
+        {"div", [{"class", "root"}],
+         [
+           {"span", [], ["Hello"]},
+           {:comment, "intersection"},
+           {"span", [], ["world"]}
+         ]}
+      ]
+
+      nodes = LazyHTML.Tree.traverse(tree, [], fn node, acc -> [node | acc] end)
+
+      assert nodes == [
+               {"div", [{"class", "root"}],
+                [{"span", [], ["Hello"]}, {:comment, "intersection"}, {"span", [], ["world"]}]},
+               {"span", [], ["world"]},
+               "world",
+               {:comment, "intersection"},
+               {"span", [], ["Hello"]},
+               "Hello",
+               {:comment, "Hello world"}
+             ]
+    end
+  end
+
   describe "postwalk/3" do
     test "does post-order traversal of the nodes and accumulates results" do
       tree = [


### PR DESCRIPTION
Phoenix LiveView is calling `LazyHTML.Tree.postwalk` in many situations in which it just needs to traverse the tree, without modifying its nodes.

This PR adds a `LazyHTML.Tree.traverse/3` function to optimize this kind of scenario in which the tree won't be modified.

Benchmark done using Floki benchmark HTML files.

```
Number of Available Cores: 12
Available memory: 31.17 GB
Elixir 1.18.4
Erlang 28.0.1
JIT enabled: true

...

##### With input big #####
Name                          ips        average  deviation         median         99th %
traverse_post_order       2659.84        0.38 ms    ±10.05%        0.37 ms        0.49 ms
traverse_pre_order         421.77        2.37 ms    ±52.29%        3.24 ms        4.16 ms
postwalk                   200.31        4.99 ms     ±6.66%        4.95 ms        6.29 ms

Comparison:
traverse_post_order       2659.84
traverse_pre_order         421.77 - 6.31x slower +1.99 ms
postwalk                   200.31 - 13.28x slower +4.62 ms

Memory usage statistics:

Name                   Memory usage
traverse_post_order            0 MB
traverse_pre_order          0.85 MB - ∞ x memory usage +0.85 MB
postwalk                    3.26 MB - ∞ x memory usage +3.26 MB

**All measurements for memory usage were the same**

##### With input medium #####
Name                          ips        average  deviation         median         99th %
traverse_post_order        7.71 K      129.79 μs    ±18.73%      125.79 μs      193.24 μs
traverse_pre_order         1.68 K      595.92 μs    ±57.80%      353.78 μs     1132.22 μs
postwalk                   1.07 K      936.26 μs    ±58.95%     1038.39 μs     2302.38 μs

Comparison:
traverse_post_order        7.71 K
traverse_pre_order         1.68 K - 4.59x slower +466.14 μs
postwalk                   1.07 K - 7.21x slower +806.47 μs

Memory usage statistics:

Name                   Memory usage
traverse_post_order            0 MB
traverse_pre_order          0.27 MB - ∞ x memory usage +0.27 MB
postwalk                    1.05 MB - ∞ x memory usage +1.05 MB

**All measurements for memory usage were the same**

##### With input small #####
Name                          ips        average  deviation         median         99th %
traverse_post_order       41.15 K       24.30 μs    ±28.19%       23.53 μs       44.25 μs
traverse_pre_order        20.60 K       48.54 μs    ±14.10%       47.75 μs       78.34 μs
postwalk                  16.56 K       60.40 μs    ±20.43%       55.00 μs       98.45 μs

Comparison:
traverse_post_order       41.15 K
traverse_pre_order        20.60 K - 2.00x slower +24.24 μs
postwalk                  16.56 K - 2.49x slower +36.10 μs

Memory usage statistics:

Name                   Memory usage
traverse_post_order            0 KB
traverse_pre_order         56.98 KB - ∞ x memory usage +56.98 KB
postwalk                  218.60 KB - ∞ x memory usage +218.60 KB
```

```
read_file = fn name ->
  __ENV__.file
  |> Path.dirname()
  |> Path.join(name)
  |> File.read!()
  |> LazyHTML.from_document()
  |> LazyHTML.to_tree()
end

inputs = %{
  "big" => read_file.("big.html"),
  "medium" => read_file.("medium.html"),
  "small" => read_file.("small.html")
}

defmodule Bench do
  def traverse_pre_order(tree, acc, fun), do: do_traverse_pre_order(tree, acc, fun)

  defp do_traverse_pre_order([[{tag, attrs, children} | rest1] | rest2], acc, fun) do
    acc = fun.({tag, attrs, children}, acc)
    do_traverse_pre_order([children, rest1 | rest2], acc, fun)
  end

  defp do_traverse_pre_order([[node | rest1] | rest2], acc, fun) do
    acc = fun.(node, acc)
    do_traverse_pre_order([rest1 | rest2], acc, fun)
  end

  defp do_traverse_pre_order([[] | rest], acc, fun), do: do_traverse_pre_order(rest, acc, fun)

  defp do_traverse_pre_order([{tag, attrs, children} | rest], acc, fun) do
    acc = fun.({tag, attrs, children}, acc)
    do_traverse_pre_order([children | rest], acc, fun)
  end

  defp do_traverse_pre_order([node | rest], acc, fun) do
    acc = fun.(node, acc)
    do_traverse_pre_order(rest, acc, fun)
  end

  defp do_traverse_pre_order([], acc, _fun), do: acc

  def traverse_post_order(tree, acc, fun), do: do_traverse_post_order(tree, acc, fun)

  defp do_traverse_post_order([], acc, _fun), do: acc

  defp do_traverse_post_order([node | rest], acc, fun) do
    acc = do_traverse_post_order(node, acc, fun)
    do_traverse_post_order(rest, acc, fun)
  end

  defp do_traverse_post_order({tag, attrs, children}, acc, fun) do
    acc = do_traverse_post_order(children, acc, fun)
    fun.({tag, attrs, children}, acc)
  end

  defp do_traverse_post_order(node, acc, fun) do
    fun.(node, acc)
  end

  def postwalk(tree, acc, fun), do: do_postwalk(tree, acc, fun)

  defp do_postwalk([], acc, _fun), do: {[], acc}

  defp do_postwalk([node | rest], acc, fun) do
    case do_postwalk(node, acc, fun) do
      {nodes, acc} when is_list(nodes) ->
        {rest, acc} = do_postwalk(rest, acc, fun)
        {nodes ++ rest, acc}

      {node, acc} ->
        {rest, acc} = do_postwalk(rest, acc, fun)
        {[node | rest], acc}
    end
  end

  defp do_postwalk({tag, attrs, children}, acc, fun) do
    {children, acc} = do_postwalk(children, acc, fun)
    fun.({tag, attrs, children}, acc)
  end

  defp do_postwalk(node, acc, fun) do
    fun.(node, acc)
  end
end

Benchee.run(
  %{
    "traverse_pre_order" => fn tree ->
      Bench.traverse_pre_order(tree, 0, fn _, acc -> acc + 1 end)
    end,
    "traverse_post_order" => fn tree ->
      Bench.traverse_post_order(tree, 0, fn _, acc -> acc + 1 end)
    end,
    "postwalk" => fn tree ->
      {_tree, acc} = Bench.postwalk(tree, 0, fn node, acc -> {node, acc + 1} end)
      acc
    end
  },
  inputs: inputs,
  pre_check: true,
  time: 10,
  memory_time: 2
)
```