### PR TITLE
Optimize LazyHTML.Tree.to_html with large trees

### DIFF
--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -498,7 +498,10 @@ defmodule LazyHTML do
   """
   @spec html_escape(String.t()) :: String.t()
   def html_escape(string) when is_binary(string) do
-    LazyHTML.Tree.append_escaped(string, "")
+    string
+    |> LazyHTML.Tree.append_escaped([])
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
   end
 
   # Access


### PR DESCRIPTION
Today `LazyHTML.Tree.to_html`  is really slow on large trees. Replacing the binary accumulator with a list makes calls with large tree significantly faster, and speeds up a little calls with smaller trees.
This does increase a little the memory usage, but considering the performance improvement seems to be worth. 

```
Elixir 1.18.4
Erlang 28.0.1
JIT enabled: true

...

##### With input big #####
Name                     ips        average  deviation         median         99th %
to_html (pr)           75.95       13.17 ms    ±14.17%       12.23 ms       17.63 ms
to_html (main)         15.60       64.09 ms    ±41.28%       74.50 ms      108.77 ms

Comparison: 
to_html (pr)           75.95
to_html (main)         15.60 - 4.87x slower +50.93 ms

Memory usage statistics:

Name              Memory usage
to_html (pr)           8.55 MB
to_html (main)         6.73 MB - 0.79x memory usage -1.81473 MB

**All measurements for memory usage were the same**

##### With input medium #####
Name                     ips        average  deviation         median         99th %
to_html (pr)          264.97        3.77 ms     ±6.03%        3.74 ms        4.90 ms
to_html (main)        245.93        4.07 ms    ±16.95%        4.04 ms        5.37 ms

Comparison: 
to_html (pr)          264.97
to_html (main)        245.93 - 1.08x slower +0.29 ms

Memory usage statistics:

Name              Memory usage
to_html (pr)           2.63 MB
to_html (main)         2.31 MB - 0.88x memory usage -0.32113 MB

**All measurements for memory usage were the same**

##### With input small #####
Name                     ips        average  deviation         median         99th %
to_html (pr)          1.36 K      736.21 μs     ±6.40%      727.97 μs      916.74 μs
to_html (main)        1.24 K      803.27 μs    ±14.04%      739.52 μs     1078.85 μs

Comparison: 
to_html (pr)          1.36 K
to_html (main)        1.24 K - 1.09x slower +67.06 μs

Memory usage statistics:

Name              Memory usage
to_html (pr)         524.79 KB
to_html (main)       517.45 KB - 0.99x memory usage -7.34375 KB
```

```
tag = "main"

read_file = fn name ->
  __ENV__.file
  |> Path.dirname()
  |> Path.join(name)
  |> File.read!()
  |> LazyHTML.from_document()
  |> LazyHTML.to_tree()
end

inputs = %{
  "big" => read_file.("big.html"),
  "medium" => read_file.("medium.html"),
  "small" => read_file.("small.html")
}

Benchee.run(
  %{
    "to_html" => &LazyHTML.Tree.to_html/1
  },
  inputs: inputs,
  pre_check: true,
  time: 10,
  memory_time: 2,
  save: [path: "benchs/results/to-html-#{tag}", tag: tag]
)

Benchee.report(load: "benchs/results/to-html-*")
```