### PR TITLE
Update lexbor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ C_SRC := $(shell pwd)/c_src
 CPPFLAGS := -shared -fPIC -fvisibility=hidden -std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-comment
 CPPFLAGS += -I$(ERTS_INCLUDE_DIR) -I$(FINE_INCLUDE_DIR)
 
-LEXBOR_DIR := $(shell pwd)/_build/c/third_party/lexbor/$(LEXBOR_VERSION)
+LEXBOR_DIR := $(shell pwd)/_build/c/third_party/lexbor/$(LEXBOR_GIT_SHA)
 ifdef CC_PRECOMPILER_CURRENT_TARGET
 	LEXBOR_BUILD_DIR := $(LEXBOR_DIR)/build-$(CC_PRECOMPILER_CURRENT_TARGET)
 else
@@ -47,4 +47,7 @@ $(LEXBOR_LIB): $(LEXBOR_DIR)
 		cmake --build .
 
 $(LEXBOR_DIR):
-	@ git clone --depth 1 --branch v$(LEXBOR_VERSION) https://github.com/lexbor/lexbor.git $(LEXBOR_DIR)
+	@ git clone --depth 1 https://github.com/lexbor/lexbor.git $(LEXBOR_DIR) && \
+		cd $(LEXBOR_DIR) && \
+		git fetch --depth 1 origin $(LEXBOR_GIT_SHA) && \
+		git checkout $(LEXBOR_GIT_SHA)

--- a/Makefile.win
+++ b/Makefile.win
@@ -5,7 +5,7 @@ C_SRC=$(MAKEDIR)\c_src
 CPPFLAGS=/LD /std:c++17 /W4 /wd4100 /wd4458 /O2 /EHsc
 CPPFLAGS=$(CPPFLAGS) /I"$(ERTS_INCLUDE_DIR)" /I"$(FINE_INCLUDE_DIR)"
 
-LEXBOR_DIR=$(MAKEDIR)\_build\c\third_party\lexbor\$(LEXBOR_VERSION)
+LEXBOR_DIR=$(MAKEDIR)\_build\c\third_party\lexbor\$(LEXBOR_GIT_SHA)
 !ifdef CC_PRECOMPILER_CURRENT_TARGET
 LEXBOR_BUILD_DIR=$(LEXBOR_DIR)\build-$(CC_PRECOMPILER_CURRENT_TARGET)
 !else
@@ -40,4 +40,7 @@ $(LEXBOR_LIB): $(LEXBOR_DIR)
 		cmake --build .
 
 $(LEXBOR_DIR):
-	@ git clone --depth 1 --branch v$(LEXBOR_VERSION) https://github.com/lexbor/lexbor.git $(LEXBOR_DIR)
+	@ git clone --depth 1 https://github.com/lexbor/lexbor.git $(LEXBOR_DIR) && \
+		cd $(LEXBOR_DIR) && \
+		git fetch --depth 1 origin $(LEXBOR_GIT_SHA) && \
+		git checkout $(LEXBOR_GIT_SHA)

--- a/c_src/lazy_html.cpp
+++ b/c_src/lazy_html.cpp
@@ -10,6 +10,9 @@
 #include <variant>
 
 #include <lexbor/html/html.h>
+#include <lexbor/css/css.h>
+#include <lexbor/selectors/selectors.h>
+#include <lexbor/dom/dom.h>
 
 namespace lazy_html {
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,8 @@
 defmodule LazyHTML.MixProject do
   use Mix.Project
 
-  @lexbor_version "2.4.0"
+  # v2.5.0 + :lexbor-contains() feature
+  @lexbor_git_sha "244b84956a6dc7eec293781d051354f351274c46"
 
   @version "0.1.7-dev"
   @description "Efficient parsing and querying of HTML documents"
@@ -21,7 +22,7 @@ defmodule LazyHTML.MixProject do
       make_env: fn ->
         %{
           "FINE_INCLUDE_DIR" => Fine.include_dir(),
-          "LEXBOR_VERSION" => @lexbor_version
+          "LEXBOR_GIT_SHA" => @lexbor_git_sha
         }
       end,
       # Precompilation


### PR DESCRIPTION
Updates to Lexbor v2.5.0 plus `:lexbor-contains()` feature (https://github.com/lexbor/lexbor/commit/244b84956a6dc7eec293781d051354f351274c46).