### PR TITLE
Implement parent_nodes + nth_child

### DIFF
--- a/c_src/lazy_html.cpp
+++ b/c_src/lazy_html.cpp
@@ -715,7 +715,7 @@ ExLazyHTML child_nodes(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
 
 FINE_NIF(child_nodes, 0);
 
-ExLazyHTML parent_nodes(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
+ExLazyHTML parent_node(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
   auto nodes = std::vector<lxb_dom_node_t *>();
   auto inserted_nodes = std::set<lxb_dom_node_t *>();
 
@@ -732,7 +732,7 @@ ExLazyHTML parent_nodes(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
   return ExLazyHTML(fine::make_resource<LazyHTML>(
       ex_lazy_html.resource->document_ref, nodes, true));
 }
-FINE_NIF(parent_nodes, ERL_NIF_DIRTY_JOB_CPU_BOUND);
+FINE_NIF(parent_node, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 std::string text(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
   auto document = ex_lazy_html.resource->document_ref->document;

--- a/c_src/lazy_html.cpp
+++ b/c_src/lazy_html.cpp
@@ -525,10 +525,8 @@ ExLazyHTML from_tree(ErlNifEnv *env, std::vector<fine::Term> tree) {
     nodes.push_back(node);
   }
 
-  bool is_fragment = true;
-  if (!nodes.empty() && lxb_html_tree_node_is(nodes.front(), LXB_TAG_HTML)) {
-    is_fragment = false;
-  }
+  bool is_fragment =
+      nodes.empty() || !lxb_html_tree_node_is(nodes.front(), LXB_TAG_HTML);
 
   auto document_ref = std::make_shared<DocumentRef>(document, is_fragment);
   document_guard.deactivate();

--- a/c_src/lazy_html.cpp
+++ b/c_src/lazy_html.cpp
@@ -852,12 +852,6 @@ std::uint64_t num_nodes(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
 
 FINE_NIF(num_nodes, 0);
 
-bool equals(ErlNifEnv *env, ExLazyHTML html_a, ExLazyHTML html_b) {
-  return (html_a.resource->document_ref == html_b.resource->document_ref &&
-          html_a.resource->nodes == html_b.resource->nodes);
-}
-FINE_NIF(equals, 0);
-
 std::vector<fine::Term> tag(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
   auto values = std::vector<fine::Term>();
 

--- a/c_src/lazy_html.cpp
+++ b/c_src/lazy_html.cpp
@@ -822,6 +822,12 @@ std::uint64_t num_nodes(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
 
 FINE_NIF(num_nodes, 0);
 
+bool equals(ErlNifEnv *env, ExLazyHTML html_a, ExLazyHTML html_b) {
+  return (html_a.resource->document_ref == html_b.resource->document_ref &&
+          html_a.resource->nodes == html_b.resource->nodes);
+}
+FINE_NIF(equals, 0);
+
 std::vector<fine::Term> tag(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
   auto values = std::vector<fine::Term>();
 

--- a/c_src/lazy_html.cpp
+++ b/c_src/lazy_html.cpp
@@ -734,6 +734,36 @@ ExLazyHTML parent_node(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
 }
 FINE_NIF(parent_node, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
+std::vector<int64_t> nth_child(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
+  auto values = std::vector<int64_t>();
+  for (auto node : ex_lazy_html.resource->nodes) {
+    if (node->type != LXB_DOM_NODE_TYPE_ELEMENT) {
+      continue;
+    }
+
+    auto parent = node->parent;
+    if (parent == NULL) {
+      // We're at the root, nth_child is 1
+      values.push_back(1);
+    } else {
+      int64_t i = 1;
+      for (auto child = lxb_dom_node_first_child(parent); child != NULL;
+           child = lxb_dom_node_next(child)) {
+        if (child == node) {
+          break;
+        }
+        if (child->type == LXB_DOM_NODE_TYPE_ELEMENT) {
+          i++;
+        }
+      }
+      values.push_back(i);
+    }
+  }
+
+  return values;
+}
+FINE_NIF(nth_child, ERL_NIF_DIRTY_JOB_CPU_BOUND);
+
 std::string text(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
   auto document = ex_lazy_html.resource->document_ref->document;
 

--- a/c_src/lazy_html.cpp
+++ b/c_src/lazy_html.cpp
@@ -4,10 +4,10 @@
 #include <functional>
 #include <memory>
 #include <optional>
-#include <set>
 #include <stdexcept>
 #include <string>
 #include <tuple>
+#include <unordered_set>
 #include <variant>
 
 #include <lexbor/html/html.h>
@@ -717,7 +717,7 @@ FINE_NIF(child_nodes, 0);
 
 ExLazyHTML parent_node(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
   auto nodes = std::vector<lxb_dom_node_t *>();
-  auto inserted_nodes = std::set<lxb_dom_node_t *>();
+  auto inserted_nodes = std::unordered_set<lxb_dom_node_t *>();
 
   for (auto node : ex_lazy_html.resource->nodes) {
     auto parent = node->parent;

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -364,7 +364,7 @@ defmodule LazyHTML do
 
       iex> lazy_html = LazyHTML.from_fragment(~S|<div><span>Hello</span> <span>world</span></div>|)
       iex> spans = LazyHTML.query(lazy_html, "span")
-      iex> LazyHTML.parent_nodes(spans)
+      iex> LazyHTML.parent_node(spans)
       #LazyHTML<
         1 node (from selector)
         #1
@@ -374,7 +374,7 @@ defmodule LazyHTML do
   The root node is always <html>, even if initialized via `from_fragment/1`:
 
       iex> lazy_html = LazyHTML.from_fragment(~S|<div>root</div>|)
-      iex> LazyHTML.parent_nodes(lazy_html)
+      iex> LazyHTML.parent_node(lazy_html)
       #LazyHTML<
         1 node (from selector)
         #1
@@ -382,33 +382,9 @@ defmodule LazyHTML do
       >
 
   """
-  @spec parent_nodes(t()) :: t()
-  def parent_nodes(lazy_html) do
-    LazyHTML.NIF.parent_nodes(lazy_html)
-  end
-
-  @doc """
-  Returns the parent nodes of the root nodes in `lazy_html`.
-  Useful when you're expecting a single, shared parent.
-  """
+  @spec parent_node(t()) :: t()
   def parent_node(lazy_html) do
-    parent = LazyHTML.NIF.parent_nodes(lazy_html)
-
-    case LazyHTML.NIF.num_nodes(parent) do
-      0 -> {:ok, nil}
-      1 -> {:ok, parent}
-      _ -> {:error, :multiple_parents}
-    end
-  end
-
-  @doc """
-  Same as `parent_node/1` but raises on multiple parents
-  """
-  def parent_node!(lazy_html) do
-    case parent_node(lazy_html) do
-      {:ok, res} -> res
-      {:error, :multiple_parents} -> raise "Selected nodes have multiple parents"
-    end
+    LazyHTML.NIF.parent_node(lazy_html)
   end
 
   @doc """

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -516,8 +516,8 @@ defmodule LazyHTML do
 
   ## Examples
 
-    iex> lazy_html = LazyHTML.from_fragment(~S|<div><span id=1>Hello</span></div>|)
-    iex> a = LazyHTML.query(lazy_html, "#1")
+    iex> lazy_html = LazyHTML.from_fragment(~S|<div><span id="a">Hello</span></div>|)
+    iex> a = LazyHTML.query(lazy_html, "#a")
     iex> b = LazyHTML.query(lazy_html, "div > span")
     iex> LazyHTML.equals?(a, b)
     true

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -371,16 +371,6 @@ defmodule LazyHTML do
         <div><span>Hello</span> <span>world</span></div>
       >
 
-  The root node is always <html>, even if initialized via `from_fragment/1`:
-
-      iex> lazy_html = LazyHTML.from_fragment(~S|<div>root</div>|)
-      iex> LazyHTML.parent_node(lazy_html)
-      #LazyHTML<
-        1 node (from selector)
-        #1
-        <html><div>root</div></html>
-      >
-
   """
   @spec parent_node(t()) :: t()
   def parent_node(lazy_html) do

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -388,6 +388,30 @@ defmodule LazyHTML do
   end
 
   @doc """
+  Returns the parent nodes of the root nodes in `lazy_html`.
+  Useful when you're expecting a single, shared parent.
+  """
+  def parent_node(lazy_html) do
+    parent = LazyHTML.NIF.parent_nodes(lazy_html)
+
+    case LazyHTML.NIF.num_nodes(parent) do
+      0 -> {:ok, nil}
+      1 -> {:ok, parent}
+      _ -> {:error, :multiple_parents}
+    end
+  end
+
+  @doc """
+  Same as `parent_node/1` but raises on multiple parents
+  """
+  def parent_node!(lazy_html) do
+    case parent_node(lazy_html) do
+      {:ok, res} -> res
+      {:error, :multiple_parents} -> raise "Selected nodes have multiple parents"
+    end
+  end
+
+  @doc """
   Returns the text content of all nodes in `lazy_html`.
 
   ## Examples

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -378,9 +378,13 @@ defmodule LazyHTML do
   end
 
   @doc """
-  Returns the positions of the selcted nodes among their siblings.
-  Note that the numbering is 1 based and doesn't include text nodes,
-  as it matches the `nth-child` CSS selector.
+  Returns the position among its siblings for every root element in `lazy_html`.
+
+  The position numbering is 1-based and only considers siblings that
+  are elements, as to match the `:nth-child` CSS pseudo-class.
+
+  Note that if there are text or comment root nodes, they are ignored,
+  and they have no corresponding number in the result.
 
   ## Examples
 
@@ -388,6 +392,7 @@ defmodule LazyHTML do
       iex> spans = LazyHTML.query(lazy_html, "span")
       iex> LazyHTML.nth_child(spans)
       [1, 2]
+
   """
   @spec nth_child(t()) :: list(integer())
   def nth_child(lazy_html) do

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -511,6 +511,29 @@ defmodule LazyHTML do
     LazyHTML.NIF.tag(lazy_html)
   end
 
+  @doc """
+  Returns true if the lazy_html is selecting the same nodes starting from the same document.
+
+  ## Examples
+
+    iex> lazy_html = LazyHTML.from_fragment(~S|<div><span id=1>Hello</span></div>|)
+    iex> a = LazyHTML.query(lazy_html, "#1")
+    iex> b = LazyHTML.query(lazy_html, "div > span")
+    iex> LazyHTML.equals?(a, b)
+    true
+
+  Note that if the lazy_htmls are created separately, they are never equal:
+
+    iex> html_a = LazyHTML.from_fragment(~S|<div>hello</div>|)
+    iex> html_b = LazyHTML.from_fragment(~S|<div>hello</div>|)
+    iex> LazyHTML.equals?(html_a, html_b)
+    false
+  """
+  @spec equals?(t(), t()) :: boolean()
+  def equals?(html_a, html_b) do
+    LazyHTML.NIF.equals(html_a, html_b)
+  end
+
   @doc ~S"""
   Escapes the given string to make a valid HTML text.
 

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -358,6 +358,36 @@ defmodule LazyHTML do
   end
 
   @doc """
+  Returns the (unique) parent nodes of the root nodes in `lazy_html`.
+
+  ## Examples
+
+      iex> lazy_html = LazyHTML.from_fragment(~S|<div><span>Hello</span> <span>world</span></div>|)
+      iex> spans = LazyHTML.query(lazy_html, "span")
+      iex> LazyHTML.parent_nodes(spans)
+      #LazyHTML<
+        1 node (from selector)
+        #1
+        <div><span>Hello</span> <span>world</span></div>
+      >
+
+  The root node is always <html>, even if initialized via `from_fragment/1`:
+
+      iex> lazy_html = LazyHTML.from_fragment(~S|<div>root</div>|)
+      iex> LazyHTML.parent_nodes(lazy_html)
+      #LazyHTML<
+        1 node (from selector)
+        #1
+        <html><div>root</div></html>
+      >
+
+  """
+  @spec parent_nodes(t()) :: t()
+  def parent_nodes(lazy_html) do
+    LazyHTML.NIF.parent_nodes(lazy_html)
+  end
+
+  @doc """
   Returns the text content of all nodes in `lazy_html`.
 
   ## Examples

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -388,6 +388,23 @@ defmodule LazyHTML do
   end
 
   @doc """
+  Returns the positions of the selcted nodes among their siblings.
+  Note that the numbering is 1 based and doesn't include text nodes,
+  as it matches the `nth-child` CSS selector.
+
+  ## Examples
+
+      iex> lazy_html = LazyHTML.from_fragment(~S|<div><span>1</span><span>2</span></div>|)
+      iex> spans = LazyHTML.query(lazy_html, "span")
+      iex> LazyHTML.nth_child(spans)
+      [1, 2]
+  """
+  @spec nth_child(t()) :: list(integer())
+  def nth_child(lazy_html) do
+    LazyHTML.NIF.nth_child(lazy_html)
+  end
+
+  @doc """
   Returns the text content of all nodes in `lazy_html`.
 
   ## Examples

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -528,29 +528,6 @@ defmodule LazyHTML do
     LazyHTML.NIF.tag(lazy_html)
   end
 
-  @doc """
-  Returns true if the lazy_html is selecting the same nodes starting from the same document.
-
-  ## Examples
-
-    iex> lazy_html = LazyHTML.from_fragment(~S|<div><span id="a">Hello</span></div>|)
-    iex> a = LazyHTML.query(lazy_html, "#a")
-    iex> b = LazyHTML.query(lazy_html, "div > span")
-    iex> LazyHTML.equals?(a, b)
-    true
-
-  Note that if the lazy_htmls are created separately, they are never equal:
-
-    iex> html_a = LazyHTML.from_fragment(~S|<div>hello</div>|)
-    iex> html_b = LazyHTML.from_fragment(~S|<div>hello</div>|)
-    iex> LazyHTML.equals?(html_a, html_b)
-    false
-  """
-  @spec equals?(t(), t()) :: boolean()
-  def equals?(html_a, html_b) do
-    LazyHTML.NIF.equals(html_a, html_b)
-  end
-
   @doc ~S"""
   Escapes the given string to make a valid HTML text.
 

--- a/lib/lazy_html/nif.ex
+++ b/lib/lazy_html/nif.ex
@@ -22,6 +22,7 @@ defmodule LazyHTML.NIF do
   def query_by_id(_lazy_html, _id), do: err!()
   def child_nodes(_lazy_html), do: err!()
   def parent_node(_lazy_html), do: err!()
+  def nth_child(_lazy_html), do: err!()
   def text(_lazy_html), do: err!()
   def attribute(_lazy_html, _name), do: err!()
   def attributes(_lazy_html), do: err!()

--- a/lib/lazy_html/nif.ex
+++ b/lib/lazy_html/nif.ex
@@ -21,6 +21,7 @@ defmodule LazyHTML.NIF do
   def filter(_lazy_html, _css_selector), do: err!()
   def query_by_id(_lazy_html, _id), do: err!()
   def child_nodes(_lazy_html), do: err!()
+  def parent_nodes(_lazy_html), do: err!()
   def text(_lazy_html), do: err!()
   def attribute(_lazy_html, _name), do: err!()
   def attributes(_lazy_html), do: err!()

--- a/lib/lazy_html/nif.ex
+++ b/lib/lazy_html/nif.ex
@@ -28,6 +28,7 @@ defmodule LazyHTML.NIF do
   def tag(_lazy_html), do: err!()
   def nodes(_lazy_html), do: err!()
   def num_nodes(_lazy_html), do: err!()
+  def equals(_lazy_html_a, _lazy_html_b), do: err!()
 
   defp err!(), do: :erlang.nif_error(:not_loaded)
 end

--- a/lib/lazy_html/nif.ex
+++ b/lib/lazy_html/nif.ex
@@ -21,7 +21,7 @@ defmodule LazyHTML.NIF do
   def filter(_lazy_html, _css_selector), do: err!()
   def query_by_id(_lazy_html, _id), do: err!()
   def child_nodes(_lazy_html), do: err!()
-  def parent_nodes(_lazy_html), do: err!()
+  def parent_node(_lazy_html), do: err!()
   def text(_lazy_html), do: err!()
   def attribute(_lazy_html, _name), do: err!()
   def attributes(_lazy_html), do: err!()

--- a/lib/lazy_html/nif.ex
+++ b/lib/lazy_html/nif.ex
@@ -29,7 +29,6 @@ defmodule LazyHTML.NIF do
   def tag(_lazy_html), do: err!()
   def nodes(_lazy_html), do: err!()
   def num_nodes(_lazy_html), do: err!()
-  def equals(_lazy_html_a, _lazy_html_b), do: err!()
 
   defp err!(), do: :erlang.nif_error(:not_loaded)
 end

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -341,6 +341,28 @@ defmodule LazyHTMLTest do
     end
   end
 
+  describe "nth_child/1" do
+    test "nth_child gives position" do
+      lazy_html =
+        LazyHTML.from_fragment("""
+        <div>
+          Text isn't counted.
+          <span>1</span>
+          <!-- neither are comments -->
+          <span>2</span>
+        </div>
+        """)
+
+      assert LazyHTML.nth_child(lazy_html) == [1]
+      assert lazy_html["div"] |> LazyHTML.nth_child() == [1]
+      assert lazy_html["span"] |> LazyHTML.nth_child() == [1, 2]
+
+      # Verify numbering matches css selector
+      assert lazy_html["span:nth-child(1)"] |> LazyHTML.text() == "1"
+      assert lazy_html["span:nth-child(2)"] |> LazyHTML.text() == "2"
+    end
+  end
+
   describe "query_by_id/2" do
     test "raises when an empty id is given" do
       assert_raise ArgumentError, ~r/id cannot be empty/, fn ->

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -250,7 +250,7 @@ defmodule LazyHTMLTest do
     end
   end
 
-  describe "parent_nodes/1" do
+  describe "parent_node/1" do
     test "from selector of nodes on different levels" do
       lazy_html =
         LazyHTML.from_fragment("""
@@ -263,20 +263,20 @@ defmodule LazyHTMLTest do
         """)
 
       spans = LazyHTML.query(lazy_html, "span")
-      parents = LazyHTML.parent_nodes(spans)
+      parents = LazyHTML.parent_node(spans)
       parent_ids = parents |> Enum.flat_map(&LazyHTML.attribute(&1, "id")) |> Enum.sort()
       assert parent_ids == ["0", "1"]
 
       # parent of div#id=0 is <html>
-      grandparents = LazyHTML.parent_nodes(parents)
+      grandparents = LazyHTML.parent_node(parents)
       assert LazyHTML.tag(grandparents) |> Enum.sort() == ["div", "html"]
 
       # parent of <html> is null, so it's filtered out
-      great_grandparents = LazyHTML.parent_nodes(grandparents)
+      great_grandparents = LazyHTML.parent_node(grandparents)
       assert great_grandparents |> Enum.count() == 1
 
       # again, parent of <html> is filtered out
-      assert LazyHTML.parent_nodes(great_grandparents) |> Enum.count() == 0
+      assert LazyHTML.parent_node(great_grandparents) |> Enum.count() == 0
     end
 
     test "from selector of nodes on same level" do
@@ -293,19 +293,20 @@ defmodule LazyHTMLTest do
         """)
 
       spans = LazyHTML.query(lazy_html, "span")
-      parents = LazyHTML.parent_nodes(spans)
+      parents = LazyHTML.parent_node(spans)
       parent_ids = parents |> Enum.flat_map(&LazyHTML.attribute(&1, "id")) |> Enum.sort()
       assert parent_ids == ["1", "2"]
 
       # since they share the same parent, we now only have one node left
-      grandparent = LazyHTML.parent_nodes(parents)
+      grandparent = LazyHTML.parent_node(parents)
       assert LazyHTML.attribute(grandparent, "id") == ["0"]
     end
 
     defp get_css_path(node, acc) do
-      parent = LazyHTML.parent_node!(node)
+      1 = Enum.count(node)
+      parent = LazyHTML.parent_node(node)
 
-      if parent do
+      if Enum.count(parent) > 0 do
         siblings =
           LazyHTML.child_nodes(parent)
           |> Enum.reject(fn n -> LazyHTML.tag(n) == [] end)

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -307,15 +307,11 @@ defmodule LazyHTMLTest do
       parent = LazyHTML.parent_node(node)
 
       if Enum.count(parent) > 0 do
-        siblings =
-          LazyHTML.child_nodes(parent)
-          |> Enum.reject(fn n -> LazyHTML.tag(n) == [] end)
-
         [tag] = LazyHTML.tag(node)
-        i = Enum.find_index(siblings, fn n -> LazyHTML.equals?(n, node) end)
+        [i] = LazyHTML.nth_child(node)
         get_css_path(parent, [{tag, i} | acc])
       else
-        acc |> Enum.map_join(" > ", fn {tag, i} -> "#{tag}:nth-child(#{i + 1})" end)
+        acc |> Enum.map_join(" > ", fn {tag, i} -> "#{tag}:nth-child(#{i})" end)
       end
     end
 

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -264,7 +264,7 @@ defmodule LazyHTMLTest do
 
       spans = LazyHTML.query(lazy_html, "span")
       parents = LazyHTML.parent_node(spans)
-      parent_ids = parents |> Enum.flat_map(&LazyHTML.attribute(&1, "id")) |> Enum.sort()
+      parent_ids = parents |> LazyHTML.attribute("id") |> Enum.sort()
       assert parent_ids == ["a", "b"]
 
       # parent of div#id="a" is null
@@ -290,7 +290,7 @@ defmodule LazyHTMLTest do
 
       spans = LazyHTML.query(lazy_html, "span")
       parents = LazyHTML.parent_node(spans)
-      parent_ids = parents |> Enum.flat_map(&LazyHTML.attribute(&1, "id")) |> Enum.sort()
+      parent_ids = parents |> LazyHTML.attribute("id") |> Enum.sort()
       assert parent_ids == ["b", "c"]
 
       # since they share the same parent, we now only have one node left

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -299,25 +299,27 @@ defmodule LazyHTMLTest do
     end
 
     defp ancestor_chain(node) do
+      parent = LazyHTML.parent_node(node)
+
       if Enum.count(node) == 0 do
         []
       else
-        ancestor_chain(LazyHTML.parent_node(node)) ++ LazyHTML.tag(node)
+        ancestor_chain(parent) ++ LazyHTML.tag(parent)
       end
     end
 
     test "last parent node is <html> if instantiated via from_document and similar" do
       lazy_html = LazyHTML.from_document("<html><body><div>root</div></body></html>")
-      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["html", "body", "div"]
+      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["html", "body"]
 
       lazy_html = LazyHTML.from_fragment("<div>root</div>")
-      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["div"]
+      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == []
 
       lazy_html = LazyHTML.from_tree([{"div", [], []}])
-      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["div"]
+      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == []
 
       lazy_html = LazyHTML.from_tree([{"html", [], [{"body", [], [{"div", [], []}]}]}])
-      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["html", "body", "div"]
+      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["html", "body"]
     end
   end
 

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -333,7 +333,7 @@ defmodule LazyHTMLTest do
       assert path == "div:nth-child(1) > div:nth-child(2) > span:nth-child(1)"
 
       span2 = LazyHTML.query(lazy_html, path)
-      assert LazyHTML.equals?(span, span2)
+      assert LazyHTML.text(span) == LazyHTML.text(span2)
     end
   end
 

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -319,40 +319,6 @@ defmodule LazyHTMLTest do
       lazy_html = LazyHTML.from_tree([{"html", [], [{"body", [], [{"div", [], []}]}]}])
       assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["html", "body", "div"]
     end
-
-    defp get_css_path(node, acc) do
-      1 = Enum.count(node)
-      parent = LazyHTML.parent_node(node)
-      [tag] = LazyHTML.tag(node)
-      [i] = LazyHTML.nth_child(node)
-
-      if Enum.count(parent) > 0 do
-        get_css_path(parent, [{tag, i} | acc])
-      else
-        [{tag, i} | acc] |> Enum.map_join(" > ", fn {tag, i} -> "#{tag}:nth-child(#{i})" end)
-      end
-    end
-
-    test "construct nth-child selector by traversing parents" do
-      lazy_html =
-        LazyHTML.from_fragment("""
-        <div>
-          <div class="wibble">
-            <span>wibble</span>
-          </div>
-          <div class="wobble">
-            <span>wobble</span>
-          </div>
-        </div>
-        """)
-
-      span = LazyHTML.query(lazy_html, ".wobble span")
-      path = get_css_path(span, [])
-      assert path == "div:nth-child(1) > div:nth-child(2) > span:nth-child(1)"
-
-      span2 = LazyHTML.query(lazy_html, path)
-      assert LazyHTML.text(span) == LazyHTML.text(span2)
-    end
   end
 
   describe "nth_child/1" do

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -298,27 +298,26 @@ defmodule LazyHTMLTest do
       assert LazyHTML.attribute(grandparent, "id") == ["a"]
     end
 
-    defp parents(node) do
+    defp ancestor_chain(node) do
       if Enum.count(node) == 0 do
         []
       else
-        tag = LazyHTML.tag(node)
-        parents(LazyHTML.parent_node(node)) ++ tag
+        ancestor_chain(LazyHTML.parent_node(node)) ++ LazyHTML.tag(node)
       end
     end
 
     test "last parent node is <html> if instantiated via from_document and similar" do
       lazy_html = LazyHTML.from_document("<html><body><div>root</div></body></html>")
-      assert parents(lazy_html["div"]) == ["html", "body", "div"]
+      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["html", "body", "div"]
 
       lazy_html = LazyHTML.from_fragment("<div>root</div>")
-      assert parents(lazy_html["div"]) == ["div"]
+      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["div"]
 
       lazy_html = LazyHTML.from_tree([{"div", [], []}])
-      assert parents(lazy_html["div"]) == ["div"]
+      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["div"]
 
       lazy_html = LazyHTML.from_tree([{"html", [], [{"body", [], [{"div", [], []}]}]}])
-      assert parents(lazy_html["div"]) == ["html", "body", "div"]
+      assert lazy_html |> LazyHTML.query("div") |> ancestor_chain() == ["html", "body", "div"]
     end
 
     defp get_css_path(node, acc) do

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -254,8 +254,8 @@ defmodule LazyHTMLTest do
     test "from selector of nodes on different levels" do
       lazy_html =
         LazyHTML.from_fragment("""
-        <div id=0>
-          <div id=1>
+        <div id="a">
+          <div id="b">
             <span>Hello</span>
           </div>
           <span>world</span>
@@ -265,9 +265,9 @@ defmodule LazyHTMLTest do
       spans = LazyHTML.query(lazy_html, "span")
       parents = LazyHTML.parent_node(spans)
       parent_ids = parents |> Enum.flat_map(&LazyHTML.attribute(&1, "id")) |> Enum.sort()
-      assert parent_ids == ["0", "1"]
+      assert parent_ids == ["a", "b"]
 
-      # parent of div#id=0 is <html>
+      # parent of div#id="a" is <html>
       grandparents = LazyHTML.parent_node(parents)
       assert LazyHTML.tag(grandparents) |> Enum.sort() == ["div", "html"]
 
@@ -282,11 +282,11 @@ defmodule LazyHTMLTest do
     test "from selector of nodes on same level" do
       lazy_html =
         LazyHTML.from_fragment("""
-        <div id=0>
-          <div id=1>
+        <div id="a">
+          <div id="b">
             <span>Hello</span>
           </div>
-          <div id=2>
+          <div id="c">
             <span>world</span>
           </div>
         </div>
@@ -295,11 +295,11 @@ defmodule LazyHTMLTest do
       spans = LazyHTML.query(lazy_html, "span")
       parents = LazyHTML.parent_node(spans)
       parent_ids = parents |> Enum.flat_map(&LazyHTML.attribute(&1, "id")) |> Enum.sort()
-      assert parent_ids == ["1", "2"]
+      assert parent_ids == ["b", "c"]
 
       # since they share the same parent, we now only have one node left
       grandparent = LazyHTML.parent_node(parents)
-      assert LazyHTML.attribute(grandparent, "id") == ["0"]
+      assert LazyHTML.attribute(grandparent, "id") == ["a"]
     end
 
     defp get_css_path(node, acc) do


### PR DESCRIPTION
Hi there :wave: 

I have a particular problem which I'm trying to solve. I need to construct a chain of `nth-child()` css selector which will uniquely select an element which I got via other means. (Context is I'm working on a test framework which randomly interacts with a page).
I couldn't find a way to do that using the current API. The only potential way to do it would be to traverse the whole html tree while collecting the path along the way until I randomly encounter the desired element.

Instead, I went ahead and implemented `parent_nodes/1` and `equals?/2`, which are enough to implement what I needed (see `get_css_path` in the test).
I think they would be good additions to the API of LazyHtml.


I also added the `parent_node!/1` helper, but I'm not so sure if that should be part of the API.

Also, there seems to be no proper way to filter out text nodes and comment nodes.
The only way I found was `LazyHTML.tag(n) == []`, which feels a bit hacky. Maybe `child_nodes/1` should accept a type filter? Or there could be a `type/1` function?

---

I know I should have opened an issue first to discuss if you're even interested in this, but it was too much fun writing some c++ for a change, I couldn't resist :smile: 