### PR TITLE
Do not start elixir_make and fine at runtime

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,7 @@ defmodule LazyHTML.MixProject do
   defp deps do
     [
       {:fine, "~> 0.1.0"},
-      {:elixir_make, "~> 0.9"},
+      {:elixir_make, "~> 0.9", runtime: false},
       {:cc_precompiler, "~> 0.1", runtime: false},
       {:ex_doc, "~> 0.36", only: :dev, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -74,7 +74,7 @@ defmodule LazyHTML.MixProject do
 
   defp deps do
     [
-      {:fine, "~> 0.1.0"},
+      {:fine, "~> 0.1.0", runtime: false},
       {:elixir_make, "~> 0.9", runtime: false},
       {:cc_precompiler, "~> 0.1", runtime: false},
       {:ex_doc, "~> 0.36", only: :dev, runtime: false}


### PR DESCRIPTION
elixir_make shouldn't be needed at runtime, this commit makes it optional.

* mix.exs (deps): Make elixir_make optional at runtime.