### PR TITLE
Add LazyHTML.css_path/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added `LazyHTML.css_paths/1` for generating queryable document-relative paths
+  for selections.
+
 ## [v0.1.12](https://github.com/dashbitco/lazy_html/tree/v0.1.11) (2026-07-20)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -47,7 +47,16 @@ hyperlinks = LazyHTML.query(lazy_html, "a")
 
 LazyHTML.attribute(hyperlinks, "href")
 #=> ["https://elixir-lang.org", "https://www.erlang.org"]
+
+LazyHTML.css_paths(hyperlinks)
+#=> [
+#=>   "div:nth-child(1) > a:nth-child(1)",
+#=>   "div:nth-child(1) > a:nth-child(2)"
+#=> ]
 ```
+
+`LazyHTML.css_paths/1` returns one document-relative, queryable CSS selector
+for each selected element, while keeping the operation batched in native code.
 
 LazyHTML also provides several high-level conveniences:
 

--- a/c_src/lazy_html.cpp
+++ b/c_src/lazy_html.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <charconv>
 #include <erl_nif.h>
 #include <fine.hpp>
 #include <functional>
@@ -12,6 +13,7 @@
 
 #include <lexbor/css/css.h>
 #include <lexbor/dom/dom.h>
+#include <lexbor/encoding/decode.h>
 #include <lexbor/html/html.h>
 #include <lexbor/selectors/selectors.h>
 
@@ -901,6 +903,124 @@ std::vector<int64_t> nth_child(ErlNifEnv *env, ExLazyHTML ex_lazy_html) {
   return values;
 }
 FINE_NIF(nth_child, ERL_NIF_DIRTY_JOB_CPU_BOUND);
+
+bool is_ascii_digit(lxb_codepoint_t codepoint) {
+  return codepoint >= '0' && codepoint <= '9';
+}
+
+bool is_ascii_letter(lxb_codepoint_t codepoint) {
+  return (codepoint >= 'a' && codepoint <= 'z') ||
+         (codepoint >= 'A' && codepoint <= 'Z');
+}
+
+void append_css_codepoint_escape(std::string &identifier,
+                                 lxb_codepoint_t codepoint) {
+  char buffer[6];
+  auto result = std::to_chars(buffer, buffer + sizeof(buffer), codepoint, 16);
+  if (result.ec != std::errc()) {
+    throw std::runtime_error("failed to escape tag name");
+  }
+
+  identifier.push_back('\\');
+  identifier.append(buffer, result.ptr);
+  identifier.push_back(' ');
+}
+
+void append_css_identifier(std::string &identifier, const lxb_char_t *data,
+                           size_t length) {
+  auto current = data;
+  auto end = data + length;
+  size_t index = 0;
+
+  while (current < end) {
+    auto codepoint = lxb_encoding_decode_valid_utf_8_single(&current, end);
+    if (codepoint == LXB_ENCODING_DECODE_ERROR) {
+      throw std::runtime_error("tag name is not valid UTF-8");
+    }
+
+    bool leading_digit = index == 0 && is_ascii_digit(codepoint);
+    bool digit_after_leading_hyphen =
+        index == 1 && data[0] == '-' && is_ascii_digit(codepoint);
+    bool control = codepoint <= 0x1F || codepoint == 0x7F;
+
+    // Lexbor's selector parser currently requires non-ASCII identifier code
+    // points to be escaped, even though CSS allows them unescaped.
+    if (leading_digit || digit_after_leading_hyphen || control ||
+        codepoint >= 0x80) {
+      append_css_codepoint_escape(identifier, codepoint);
+    } else if (is_ascii_letter(codepoint) || is_ascii_digit(codepoint) ||
+               codepoint == '-' || codepoint == '_') {
+      if (index == 0 && codepoint == '-' && length == 1) {
+        identifier.append("\\-");
+      } else {
+        identifier.push_back(static_cast<char>(codepoint));
+      }
+    } else {
+      identifier.push_back('\\');
+      identifier.push_back(static_cast<char>(codepoint));
+    }
+
+    index++;
+  }
+}
+
+std::vector<std::string> css_paths(ErlNifEnv *env,
+                                   ExLazyHTML ex_lazy_html) {
+  auto paths = std::vector<std::string>();
+  bool is_fragment = ex_lazy_html.resource->document_ref->is_fragment;
+
+  for (auto node : ex_lazy_html.resource->nodes) {
+    if (node->type != LXB_DOM_NODE_TYPE_ELEMENT) {
+      continue;
+    }
+
+    auto segments = std::vector<std::string>();
+    auto current = node;
+
+    while (current != NULL && current->type == LXB_DOM_NODE_TYPE_ELEMENT &&
+           !(is_fragment && lxb_html_tree_node_is(current, LXB_TAG_HTML))) {
+      auto element = lxb_dom_interface_element(current);
+
+      size_t name_length;
+      auto name = lxb_dom_element_qualified_name(element, &name_length);
+      if (name == NULL) {
+        throw std::runtime_error("failed to read tag name");
+      }
+
+      int64_t position = 1;
+      // Scanning backwards avoids building a child-index table, but makes a
+      // batch selecting many siblings O(n^2) in the worst case.
+      for (auto sibling = lxb_dom_node_prev(current); sibling != NULL;
+           sibling = lxb_dom_node_prev(sibling)) {
+        if (sibling->type == LXB_DOM_NODE_TYPE_ELEMENT) {
+          position++;
+        }
+      }
+
+      auto segment = std::string();
+      append_css_identifier(segment, name, name_length);
+      segment.append(":nth-child(");
+      segment.append(std::to_string(position));
+      segment.push_back(')');
+      segments.push_back(std::move(segment));
+
+      current = lxb_dom_node_parent(current);
+    }
+
+    auto path = std::string();
+    for (auto segment = segments.rbegin(); segment != segments.rend();
+         ++segment) {
+      if (!path.empty()) {
+        path.append(" > ");
+      }
+      path.append(*segment);
+    }
+    paths.push_back(std::move(path));
+  }
+
+  return paths;
+}
+FINE_NIF(css_paths, ERL_NIF_DIRTY_JOB_CPU_BOUND);
 
 void node_text(lxb_dom_node_t *node, std::string &content,
                std::optional<std::string> &separator) {

--- a/lib/lazy_html.ex
+++ b/lib/lazy_html.ex
@@ -400,6 +400,34 @@ defmodule LazyHTML do
   end
 
   @doc """
+  Returns a document-relative CSS path for each selected element in `lazy_html`.
+
+  To build each path, LazyHTML walks from the selected element towards the
+  document root. At every level it records the element's qualified tag name
+  and its 1-based `:nth-child` position. The resulting path can be passed back
+  to `query/2` to find the same element in the original document or fragment.
+
+  As with `tag/1` and `nth_child/1`, text and comment nodes in the selection
+  are skipped.
+
+  ## Examples
+
+      iex> ~S|<main><span>first</span><span>second</span></main>|
+      ...> |> LazyHTML.from_fragment()
+      ...> |> LazyHTML.query("span")
+      ...> |> LazyHTML.css_paths()
+      [
+        "main:nth-child(1) > span:nth-child(1)",
+        "main:nth-child(1) > span:nth-child(2)"
+      ]
+
+  """
+  @spec css_paths(t()) :: list(String.t())
+  def css_paths(%LazyHTML{} = lazy_html) do
+    LazyHTML.NIF.css_paths(lazy_html)
+  end
+
+  @doc """
   Returns the text content of all nodes in `lazy_html`.
 
   ## Options

--- a/lib/lazy_html/nif.ex
+++ b/lib/lazy_html/nif.ex
@@ -23,6 +23,7 @@ defmodule LazyHTML.NIF do
   def child_nodes(_lazy_html), do: err!()
   def parent_node(_lazy_html), do: err!()
   def nth_child(_lazy_html), do: err!()
+  def css_paths(_lazy_html), do: err!()
   def text(_lazy_html, _separator), do: err!()
   def attribute(_lazy_html, _name), do: err!()
   def attributes(_lazy_html), do: err!()

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -442,44 +442,23 @@ defmodule LazyHTMLTest do
              end) == [["gradient"], ["circle"]]
     end
 
-    test "escapes tag names that contain CSS syntax" do
+    test "escapes CSS syntax in custom tag names" do
       fragment =
         LazyHTML.from_fragment("""
-        <foo:bar id="colon"></foo:bar>
-        <foo.bar id="dot"></foo.bar>
-        <foo#bar id="hash"></foo#bar>
+        <my-widget.compact id="dot"></my-widget.compact>
+        <svg:rect id="colon"></svg:rect>
         """)
 
       elements = LazyHTML.query(fragment, "*")
 
       assert LazyHTML.css_paths(elements) == [
-               ~S|foo\:bar:nth-child(1)|,
-               ~S|foo\.bar:nth-child(2)|,
-               ~S|foo\#bar:nth-child(3)|
+               ~S|my-widget\.compact:nth-child(1)|,
+               ~S|svg\:rect:nth-child(2)|
              ]
 
       assert Enum.map(LazyHTML.css_paths(elements), fn path ->
                fragment |> LazyHTML.query(path) |> LazyHTML.attribute("id")
-             end) == [["colon"], ["dot"], ["hash"]]
-    end
-
-    test "escapes leading digits and non-ASCII tag names" do
-      fragment =
-        LazyHTML.from_tree([
-          {"1st-item", [{"id", "digit"}], []},
-          {"\u00E9clair", [{"id", "unicode"}], []}
-        ])
-
-      elements = LazyHTML.query(fragment, "*")
-
-      assert LazyHTML.css_paths(elements) == [
-               ~S|\31 st-item:nth-child(1)|,
-               ~S|\e9 clair:nth-child(2)|
-             ]
-
-      assert Enum.map(LazyHTML.css_paths(elements), fn path ->
-               fragment |> LazyHTML.query(path) |> LazyHTML.attribute("id")
-             end) == [["digit"], ["unicode"]]
+             end) == [["dot"], ["colon"]]
     end
 
     test "treats template elements as regular document elements" do

--- a/test/lazy_html_test.exs
+++ b/test/lazy_html_test.exs
@@ -375,6 +375,133 @@ defmodule LazyHTMLTest do
     end
   end
 
+  describe "css_paths/1" do
+    test "returns queryable document-relative paths" do
+      document =
+        LazyHTML.from_document("""
+        <html>
+          <head><title>Example</title></head>
+          <body><main><p id="first"></p><p id="second"></p></main></body>
+        </html>
+        """)
+
+      paragraphs = LazyHTML.query(document, "p")
+
+      assert LazyHTML.css_paths(paragraphs) == [
+               "html:nth-child(1) > body:nth-child(2) > main:nth-child(1) > p:nth-child(1)",
+               "html:nth-child(1) > body:nth-child(2) > main:nth-child(1) > p:nth-child(2)"
+             ]
+
+      assert Enum.map(LazyHTML.css_paths(paragraphs), fn path ->
+               document |> LazyHTML.query(path) |> LazyHTML.attribute("id")
+             end) == [["first"], ["second"]]
+    end
+
+    test "distinguishes duplicate siblings across multiple fragment roots" do
+      fragment =
+        LazyHTML.from_fragment("""
+        text
+        <section><span id="one"></span><span id="two"></span></section>
+        <!-- comment -->
+        <section><span id="three"></span></section>
+        """)
+
+      spans = LazyHTML.query(fragment, "span")
+
+      assert LazyHTML.css_paths(spans) == [
+               "section:nth-child(1) > span:nth-child(1)",
+               "section:nth-child(1) > span:nth-child(2)",
+               "section:nth-child(2) > span:nth-child(1)"
+             ]
+
+      assert length(LazyHTML.css_paths(fragment)) == length(LazyHTML.tag(fragment))
+
+      assert Enum.map(LazyHTML.css_paths(spans), fn path ->
+               fragment |> LazyHTML.query(path) |> LazyHTML.attribute("id")
+             end) == [["one"], ["two"], ["three"]]
+    end
+
+    test "uses qualified SVG tag names" do
+      fragment =
+        LazyHTML.from_fragment("""
+        <svg>
+          <defs><linearGradient id="gradient"></linearGradient></defs>
+          <circle id="circle"></circle>
+        </svg>
+        """)
+
+      elements = LazyHTML.query(fragment, "linearGradient, circle")
+
+      assert LazyHTML.css_paths(elements) == [
+               "svg:nth-child(1) > defs:nth-child(1) > linearGradient:nth-child(1)",
+               "svg:nth-child(1) > circle:nth-child(2)"
+             ]
+
+      assert Enum.map(LazyHTML.css_paths(elements), fn path ->
+               fragment |> LazyHTML.query(path) |> LazyHTML.attribute("id")
+             end) == [["gradient"], ["circle"]]
+    end
+
+    test "escapes tag names that contain CSS syntax" do
+      fragment =
+        LazyHTML.from_fragment("""
+        <foo:bar id="colon"></foo:bar>
+        <foo.bar id="dot"></foo.bar>
+        <foo#bar id="hash"></foo#bar>
+        """)
+
+      elements = LazyHTML.query(fragment, "*")
+
+      assert LazyHTML.css_paths(elements) == [
+               ~S|foo\:bar:nth-child(1)|,
+               ~S|foo\.bar:nth-child(2)|,
+               ~S|foo\#bar:nth-child(3)|
+             ]
+
+      assert Enum.map(LazyHTML.css_paths(elements), fn path ->
+               fragment |> LazyHTML.query(path) |> LazyHTML.attribute("id")
+             end) == [["colon"], ["dot"], ["hash"]]
+    end
+
+    test "escapes leading digits and non-ASCII tag names" do
+      fragment =
+        LazyHTML.from_tree([
+          {"1st-item", [{"id", "digit"}], []},
+          {"\u00E9clair", [{"id", "unicode"}], []}
+        ])
+
+      elements = LazyHTML.query(fragment, "*")
+
+      assert LazyHTML.css_paths(elements) == [
+               ~S|\31 st-item:nth-child(1)|,
+               ~S|\e9 clair:nth-child(2)|
+             ]
+
+      assert Enum.map(LazyHTML.css_paths(elements), fn path ->
+               fragment |> LazyHTML.query(path) |> LazyHTML.attribute("id")
+             end) == [["digit"], ["unicode"]]
+    end
+
+    test "treats template elements as regular document elements" do
+      fragment =
+        LazyHTML.from_fragment("""
+        <template id="first"><div>content</div></template>
+        <template id="second"><span>content</span></template>
+        """)
+
+      templates = LazyHTML.query(fragment, "template")
+
+      assert LazyHTML.css_paths(templates) == [
+               "template:nth-child(1)",
+               "template:nth-child(2)"
+             ]
+
+      assert Enum.map(LazyHTML.css_paths(templates), fn path ->
+               fragment |> LazyHTML.query(path) |> LazyHTML.attribute("id")
+             end) == [["first"], ["second"]]
+    end
+  end
+
   describe "query_by_id/2" do
     test "raises when an empty id is given" do
       assert_raise ArgumentError, ~r/id cannot be empty/, fn ->


### PR DESCRIPTION
Implement `LazyHTML.css_path/1` via NIF.
Return a document-relative CSS path for each selected element.

```elixir
~S|<main><span>first</span><span>second</span></main>|
|> LazyHTML.from_fragment()
|> LazyHTML.query("span")
|> LazyHTML.css_path()

    [
      "main:nth-child(1) > span:nth-child(1)",
      "main:nth-child(1) > span:nth-child(2)"
    ]
```

To build each path, walk from selected element towards document root.
At every level record element's qualified tag name and its 1-based `:nth-child` position.
The resulting path can be passed back to `query/2` to find the same element in the original document or fragment.

As with `tag/1` and `nth_child/1`, text and comment nodes in the selection are skipped.

## Why

### Use case

I'm working on [ftes/fluffy](https://github.com/ftes/fluffy). It applies Playwright-style locators and actions to Phoenix-rendered HTML through LazyHTML. It uses structural paths to join locator results back to a document index for ancestry, document order, form ownership, actionability, and render reconciliation. A batched API provides that bridge without repeated NIF calls or reliance on private Lexbor pointers.

### Performance

`css_path/1` is the batched composition of `parent_node/1` and `nth_child/1` via a NIF.
The same composition implemented in Elixir would require several NIF calls.

See benchark below.

### Prior art

Comparable node-to-path APIs exist in [lxml](https://lxml.de/apidoc/lxml.etree.html), [Nokogiri](https://nokogiri.org/rdoc/Nokogiri/XML/Node.html#method-i-css_path), [jsoup](https://jsoup.org/apidocs/org/jsoup/nodes/Element.html#cssSelector()), and [Html Agility Pack](https://documentation.help/HtmlAgilityPack/44e12d6f-4137-9f94-0430-b4d6b0231a01.htm).


## Benchmark

This PR vs. Elixir-based composition of `tag/1`, `nth_child/1` and `parent_node/1`.

Output:
```
Name                                    ips        average  deviation         median         99th %
css_path/1 (native, this PR)        1.33 K        0.75 ms     ±5.11%        0.75 ms        0.88 ms
composed public API (Elixir)       0.0424 K       23.56 ms     ±2.08%       23.42 ms       25.60 ms

Comparison:
css_path/1 (native, this PR)        1.33 K
composed public API (Elixir)       0.0424 K - 31.34x slower +22.81 ms
````

<details>

<summary>

`tmp/benchmark.exs`

</summary>

```elixir
# Save in checked out workspace as tmp/benchmark.exs
# Run via `elixir tmp/benchmark.exs`

Mix.install([
  {:benchee, "~> 1.4"},
  {:lazy_html, path: File.cwd!()}
])

defmodule CSSPathBenchmark do
  def public_api_path(lazy_html) do
    Enum.map(lazy_html, &public_api_path(&1, []))
  end

  defp public_api_path(node, segments) do
    [tag] = LazyHTML.tag(node)
    [position] = LazyHTML.nth_child(node)
    segments = ["#{tag}:nth-child(#{position})" | segments]
    parent = LazyHTML.parent_node(node)

    if Enum.empty?(parent) do
      Enum.join(segments, " > ")
    else
      public_api_path(parent, segments)
    end
  end
end

items =
  Enum.map_join(1..1_000, fn index ->
    ~s|<li><a href="/#{index}">Item #{index}</a></li>|
  end)

links =
  "<main><ul>#{items}</ul></main>"
  |> LazyHTML.from_document()
  |> LazyHTML.query("a")

native = fn -> LazyHTML.css_path(links) end
elixir = fn -> CSSPathBenchmark.public_api_path(links) end

if native.() != elixir.() do
  raise "implementations returned different paths"
end

Benchee.run(
  %{
    "css_path/1 (native, this PR)" => native,
    "composed public API (Elixir)" => elixir
  },
  time: 3,
  warmup: 0
)
```

</details>
